### PR TITLE
Ajout de tests de non-régression pour DataValidator et sécurisation de la validation des liens

### DIFF
--- a/importdata/src/main/java/fr/expand/project/importdata/validation/DataValidator.java
+++ b/importdata/src/main/java/fr/expand/project/importdata/validation/DataValidator.java
@@ -1,6 +1,7 @@
 package fr.expand.project.importdata.validation;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -62,7 +63,11 @@ public class DataValidator {
         
         // Validate links
         if (data.getLINKS() != null && data.getLINKS().getLINK() != null) {
-            validateLinks(data.getLINKS().getLINK(), data.getOBJECTS().getOBJECT());
+            List<OBJECT> objects = Collections.emptyList();
+            if (data.getOBJECTS() != null && data.getOBJECTS().getOBJECT() != null) {
+                objects = data.getOBJECTS().getOBJECT();
+            }
+            validateLinks(data.getLINKS().getLINK(), objects);
         }
         
         LOGGER.info("Validation completed. Errors: " + errors.size() + ", Warnings: " + warnings.size());

--- a/importdata/src/test/java/fr/expand/project/importdata/DataValidatorTests.java
+++ b/importdata/src/test/java/fr/expand/project/importdata/DataValidatorTests.java
@@ -13,6 +13,7 @@ import fr.expand.project.importdata.dto.generated.OBJECTS;
 import fr.expand.project.importdata.dto.util.DataPackDtoUtils;
 import fr.expand.project.importdata.model.ModelManager;
 import fr.expand.project.importdata.validation.DataValidator;
+import fr.expand.project.importdata.validation.ValidationError;
 import fr.expand.project.importdata.validation.ValidationResult;
 
 public class DataValidatorTests {
@@ -37,9 +38,8 @@ public class DataValidatorTests {
 
         ValidationResult result = new DataValidator().validate(data);
 
-        Assert.assertTrue(result.hasErrors());
-        Assert.assertTrue(result.getErrorMessages().stream()
-                .anyMatch(message -> message.contains("Missing required attribute: PRENOM")));
+        Assert.assertFalse(result.isValid());
+        Assert.assertTrue(containsErrorMessage(result, "Missing required attribute: PRENOM"));
     }
 
     @Test
@@ -57,9 +57,8 @@ public class DataValidatorTests {
 
         ValidationResult result = new DataValidator().validate(data);
 
-        Assert.assertTrue(result.hasErrors());
-        Assert.assertTrue(result.getErrorMessages().stream()
-                .anyMatch(message -> message.contains("Invalid type for attribute 'AGE': expected INTEGER")));
+        Assert.assertFalse(result.isValid());
+        Assert.assertTrue(containsErrorMessage(result, "Invalid type for attribute 'AGE': expected INTEGER"));
     }
 
     @Test
@@ -84,8 +83,17 @@ public class DataValidatorTests {
 
         ValidationResult result = new DataValidator().validate(data);
 
-        Assert.assertTrue(result.hasErrors());
-        Assert.assertTrue(result.getErrorMessages().stream().anyMatch(message -> message.contains("Source object not found")));
-        Assert.assertTrue(result.getErrorMessages().stream().anyMatch(message -> message.contains("Target object not found")));
+        Assert.assertFalse(result.isValid());
+        Assert.assertTrue(containsErrorMessage(result, "Source object not found"));
+        Assert.assertTrue(containsErrorMessage(result, "Target object not found"));
+    }
+
+    private boolean containsErrorMessage(ValidationResult result, String expectedFragment) {
+        for (ValidationError error : result.getErrors()) {
+            if (error.getMessage() != null && error.getMessage().contains(expectedFragment)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/importdata/src/test/java/fr/expand/project/importdata/DataValidatorTests.java
+++ b/importdata/src/test/java/fr/expand/project/importdata/DataValidatorTests.java
@@ -1,0 +1,91 @@
+package fr.expand.project.importdata;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import fr.expand.project.importdata.dto.DataPackAttribute;
+import fr.expand.project.importdata.dto.DataPackObject;
+import fr.expand.project.importdata.dto.generated.DATAS;
+import fr.expand.project.importdata.dto.generated.LINK;
+import fr.expand.project.importdata.dto.generated.LINKS;
+import fr.expand.project.importdata.dto.generated.OBJECTS;
+import fr.expand.project.importdata.dto.util.DataPackDtoUtils;
+import fr.expand.project.importdata.model.ModelManager;
+import fr.expand.project.importdata.validation.DataValidator;
+import fr.expand.project.importdata.validation.ValidationResult;
+
+public class DataValidatorTests {
+
+    @Before
+    public void setupModel() throws Exception {
+        ModelManager manager = ModelManager.getInstance();
+        manager.clearModels();
+        manager.loadModelFromResource("model/example_social_network_model.xml");
+    }
+
+    @Test
+    public void validate_shouldDetectMissingRequiredAttribute() {
+        DATAS data = new DATAS();
+        data.setOBJECTS(new OBJECTS());
+
+        DataPackObject person = new DataPackObject();
+        person.setID(1);
+        person.setTYPE("PERSONNE");
+        person.getATTRIBUTE().add(new DataPackAttribute("NOM", "Dupont"));
+        data.getOBJECTS().getOBJECT().add(person);
+
+        ValidationResult result = new DataValidator().validate(data);
+
+        Assert.assertTrue(result.hasErrors());
+        Assert.assertTrue(result.getErrorMessages().stream()
+                .anyMatch(message -> message.contains("Missing required attribute: PRENOM")));
+    }
+
+    @Test
+    public void validate_shouldDetectInvalidAttributeType() {
+        DATAS data = new DATAS();
+        data.setOBJECTS(new OBJECTS());
+
+        DataPackObject person = new DataPackObject();
+        person.setID(2);
+        person.setTYPE("PERSONNE");
+        person.getATTRIBUTE().add(new DataPackAttribute("NOM", "Martin"));
+        person.getATTRIBUTE().add(new DataPackAttribute("PRENOM", "Alice"));
+        person.getATTRIBUTE().add(new DataPackAttribute("AGE", "vingt-cinq"));
+        data.getOBJECTS().getOBJECT().add(person);
+
+        ValidationResult result = new DataValidator().validate(data);
+
+        Assert.assertTrue(result.hasErrors());
+        Assert.assertTrue(result.getErrorMessages().stream()
+                .anyMatch(message -> message.contains("Invalid type for attribute 'AGE': expected INTEGER")));
+    }
+
+    @Test
+    public void validate_shouldHandleLinksWhenObjectsSectionIsMissing() {
+        DATAS data = new DATAS();
+        data.setLINKS(new LINKS());
+
+        LINK link = new LINK();
+        link.setTYPE("CONNAIT");
+
+        DataPackObject source = new DataPackObject();
+        source.setID(1);
+        source.setTYPE("PERSONNE");
+
+        DataPackObject target = new DataPackObject();
+        target.setID(2);
+        target.setTYPE("PERSONNE");
+
+        link.setOBJLINKA(DataPackDtoUtils.createObjLink(source));
+        link.setOBJLINKB(DataPackDtoUtils.createObjLink(target));
+        data.getLINKS().getLINK().add(link);
+
+        ValidationResult result = new DataValidator().validate(data);
+
+        Assert.assertTrue(result.hasErrors());
+        Assert.assertTrue(result.getErrorMessages().stream().anyMatch(message -> message.contains("Source object not found")));
+        Assert.assertTrue(result.getErrorMessages().stream().anyMatch(message -> message.contains("Target object not found")));
+    }
+}


### PR DESCRIPTION
### Motivation
- Protéger le comportement critique de la validation des données pour qu'il soit couvert par la CI et prévenir les régressions sur les règles métier d'attributs et de liens. 
- Éviter un plantage (`NullPointerException`) lorsque des payloads contiennent une section `LINKS` sans section `OBJECTS` afin d'obtenir des erreurs métier au lieu d'un crash.

### Description
- Ajout de la suite de tests `DataValidatorTests` dans `importdata/src/test/java/fr/expand/project/importdata/DataValidatorTests.java` qui couvre la détection d'attribut requis manquant, la vérification de type d'attribut invalide, et la validation de liens lorsque `OBJECTS` est absent. 
- Durcissement de `DataValidator.validate` (fichier `importdata/src/main/java/fr/expand/project/importdata/validation/DataValidator.java`) pour utiliser `Collections.emptyList()` par défaut et éviter d'appeler `data.getOBJECTS().getOBJECT()` quand `OBJECTS` est null. 
- Import ajouté de `java.util.Collections` pour supporter la liste vide par défaut. 

### Testing
- Tentative d'exécution des tests avec `mvn -pl importdata -Dtest=DataValidatorTests test` a été faite automatiquement dans l'environnement. 
- Exécution des tests impossible ici car la résolution du plugin Maven `org.codehaus.mojo:jaxb2-maven-plugin:3.1.0` a renvoyé une erreur HTTP 403 depuis Maven Central, donc les tests n'ont pas pu être lancés dans cet environnement d'exécution.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698accb6fb88832999319e47fb9722c0)